### PR TITLE
Add non-breaking spaces in "IBM i"

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
               <img src="img/death-2024663_640.png">
             </div>
             <div class="col-md-10">
-              <h1>Support for IBM i v7.1 will end in...</h1>
+              <h1>Support for IBM&nbsp;i v7.1 will end in...</h1>
               <div class="flip-countdown-container">
                 <div id="ibmi-71-countdown"></div>
               </div>
@@ -47,19 +47,19 @@
         </ul>
         <div class="tab-content" id="TabsContent">
           <div class="tab-pane fade show active" id="WhatToDo" role="tabpanel" aria-labelledby="WhatToDoTab">
-            <h3>Don't worry, you can still upgrade to IBM i 7.2 or better yet IBM i 7.3!</h3>
+            <h3>Don't worry, you can still upgrade to IBM&nbsp;i 7.2 or better yet IBM&nbsp;i 7.3!</h3>
             <ul>
               <li>
-                Download a new, supported version of IBM i from the
+                Download a new, supported version of IBM&nbsp;i from the
                 <a href="https://www-304.ibm.com/servers/eserver/ess/index.wss" rel="nofollow">IBM ESS website</a>.
               </li>
               <li>
-                Check out what's new for IBM i 7.3
+                Check out what's new for IBM&nbsp;i 7.3
                 <a href="https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_73/db2/rbafzwhatsnew.htm" rel="nofollow">here</a>.
               </li>
               <li>
                 Read the
-                <a href="https://www.ibm.com/support/knowledgecenter/ko/ssw_ibm_i_73/rzaq9/rzaq9.pdf" rel="nofollow">IBM i 7.3 Memo To Users</a>.
+                <a href="https://www.ibm.com/support/knowledgecenter/ko/ssw_ibm_i_73/rzaq9/rzaq9.pdf" rel="nofollow">IBM&nbsp;i 7.3 Memo To Users</a>.
               </li>
               <li>
                 Read the official
@@ -69,25 +69,25 @@
             </ul>
           </div>
           <div class="tab-pane fade" id="Reasons" role="tabpanel" aria-labelledby="ReasonsTab">
-            <h3>Reasons to upgrade from IBM i 7.1</h3>
+            <h3>Reasons to upgrade from IBM&nbsp;i 7.1</h3>
             <ol>
               <li>
-                If you remain on IBM i 7.1, IBM Software Maintenance will cost much more with an added Extended Support
+                If you remain on IBM&nbsp;i 7.1, IBM Software Maintenance will cost much more with an added Extended Support
                 charge after April 30th, 2018.
               </li>
               <li>
-                The IBM HTTP Server that shipped with IBM i 7.1 (Apache 2.2) will go out of support December 31st, 2017.
-                This means that IBM i 7.1 will no longer be PCI compliant from a HTTP perspective. IBM HTTP Server has
-                been upgraded to Apache 2.4 in IBM i releases 7.2 and 7.3.
+                The IBM HTTP Server that shipped with IBM&nbsp;i 7.1 (Apache 2.2) will go out of support December 31st, 2017.
+                This means that IBM&nbsp;i 7.1 will no longer be PCI compliant from a HTTP perspective. IBM HTTP Server has
+                been upgraded to Apache 2.4 in IBM&nbsp;i releases 7.2 and 7.3.
               </li>
               <li>
-                The default Java version on IBM i 7.1 is version 6. This will be going end of support on December 31st,
-                2017 as well. It’s recommended you upgrade to Java 7 or 8 no matter what version of IBM i you have.
+                The default Java version on IBM&nbsp;i 7.1 is version 6. This will be going end of support on December 31st,
+                2017 as well. It’s recommended you upgrade to Java 7 or 8 no matter what version of IBM&nbsp;i you have.
                 There will be no more fix packs for Java 6.
               </li>
               <li>
-                75% of ciphers offered in IBM i 7.1 are not deemed secure. If securing your system is a priority to you,
-                consider upgrading to IBM i 7.3, which offers far more secure cipher suites.
+                75% of ciphers offered in IBM&nbsp;i 7.1 are not deemed secure. If securing your system is a priority to you,
+                consider upgrading to IBM&nbsp;i 7.3, which offers far more secure cipher suites.
               </li>
             </ol>
           </div>
@@ -95,8 +95,8 @@
             <h3>Still not convinced?</h3>
             <p>Read more on the 7.2 and 7.3 Base Enhancements!</p>
             <ul>
-              <li><a href="https://www.ibm.com/developerworks/community/wikis/home?lang=en#!/wiki/IBM%20i%20Technology%20Updates/page/IBM%20i%207.2%20-%20Base%20Enhancements">IBM i 7.2 Base Enhancments</a></li>
-              <li><a href="https://www.ibm.com/developerworks/community/wikis/home?lang=en#!/wiki/IBM%20i%20Technology%20Updates/page/IBM%20i%207.3%20-%20Base%20Enhancements">IBM i 7.3 Base Enhancements</a></li>
+              <li><a href="https://www.ibm.com/developerworks/community/wikis/home?lang=en#!/wiki/IBM%20i%20Technology%20Updates/page/IBM%20i%207.2%20-%20Base%20Enhancements">IBM&nbsp;i 7.2 Base Enhancments</a></li>
+              <li><a href="https://www.ibm.com/developerworks/community/wikis/home?lang=en#!/wiki/IBM%20i%20Technology%20Updates/page/IBM%20i%207.3%20-%20Base%20Enhancements">IBM&nbsp;i 7.3 Base Enhancements</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Prevent IBM i name from being split across lines. This is especially
noticeable in the "Support for IBM i v7.1..." header on mobile, but
I changed all other applicable instances as well.

![screenshot](https://user-images.githubusercontent.com/7004340/34469115-7c5a965a-eedd-11e7-81a6-7ba2d8ae88df.png)
